### PR TITLE
Update api tests to close knex connection on completion

### DIFF
--- a/__tests__/integration/api/api.tasks.test.js
+++ b/__tests__/integration/api/api.tasks.test.js
@@ -3,11 +3,9 @@ const supertest = require('supertest');
 const { getTracker, MockClient } = require('knex-mock-client');
 const { router, urlTasks } = require('../../../routes');
 
-jest.mock('../../../config/knex', () => {
-  // eslint-disable-next-line global-require
-  const knex = require('knex');
-  return knex({ client: MockClient });
-});
+jest.mock('../../../knexfile', () => ({
+  test: { client: MockClient }
+}));
 
 const testTask = {
   site_id: 2,
@@ -39,6 +37,7 @@ app.use(express.json());
 app.use(router);
 
 beforeEach(() => {
+  tracker.on.select('select 1+1').responseOnce([]);
   tracker.on.select('* from "proxies"').responseOnce([]);
 });
 
@@ -49,6 +48,15 @@ afterEach(() => {
 beforeAll(() => {
   request = supertest(app);
   tracker = getTracker();
+});
+
+afterAll(() => {
+  // This needs to be imported here to use the mock connection
+  jest.unmock('../../../knexfile');
+  jest.resetModules();
+  // eslint-disable-next-line global-require
+  const knex = require('../../../config/knex');
+  knex.close();
 });
 
 describe('GET /tasks', () => {


### PR DESCRIPTION
This change stops the mocking of the knex database and closes the connection. This was introduced as although the tests finished, the database pool was still active, so the test ran indefinitely