### PR TITLE
Update api tests to close knex connection using destroy method

### DIFF
--- a/__tests__/integration/api/api.addresses.test.js
+++ b/__tests__/integration/api/api.addresses.test.js
@@ -56,7 +56,7 @@ afterAll(() => {
   jest.resetModules();
   // eslint-disable-next-line global-require
   const knex = require('../../../config/knex');
-  knex.close();
+  knex.destroy();
 });
 
 describe('GET /addresses', () => {

--- a/__tests__/integration/api/api.proxies.test.js
+++ b/__tests__/integration/api/api.proxies.test.js
@@ -50,7 +50,7 @@ afterAll(() => {
   jest.resetModules();
   // eslint-disable-next-line global-require
   const knex = require('../../../config/knex');
-  knex.close();
+  knex.destroy();
 });
 
 describe('GET /proxies', () => {

--- a/__tests__/integration/api/api.tasks.test.js
+++ b/__tests__/integration/api/api.tasks.test.js
@@ -56,7 +56,7 @@ afterAll(() => {
   jest.resetModules();
   // eslint-disable-next-line global-require
   const knex = require('../../../config/knex');
-  knex.close();
+  knex.destroy();
 });
 
 describe('GET /tasks', () => {


### PR DESCRIPTION
The previous commit used a method to close the database connection which doesn't work in jest but works in the IDE?!. This should be the last of the changes.