### PR TITLE
fix issue where 'this' is undefined 

### DIFF
--- a/helpers/task-cache.js
+++ b/helpers/task-cache.js
@@ -9,7 +9,7 @@ export const retrievePageFromTaskCache = ({ taskId }) => {
 };
 
 export const removePageFromTaskCache = async ({ taskId }) => {
-  const page = this.retrievePageFromTaskCache({ taskId });
+  const page = retrievePageFromTaskCache({ taskId });
   if (page) await page.close();
   delete taskCache[taskId];
 };


### PR DESCRIPTION
I noticed inside `helpers/task-cache.js` we have this particular function declared:
```
export const removePageFromTaskCache = async ({ taskId }) => {
  const page = this.retrievePageFromTaskCache({ taskId });
  if (page) await page.close();
  delete taskCache[taskId];
};
```
We can remove `this` from `const page = this.retrievePageFromTaskCache({ taskId });` and that should resolve the issue with stopping tasks.

I have a branch with the fix but I can't push it to this repo. easy fix.

<img width="711" alt="Screen Shot 2022-04-14 at 10 10 50 AM" src="https://user-images.githubusercontent.com/4186033/163417963-a0351cb2-0b9a-4923-b25f-fe61cd84f24f.png">

