### PR TITLE
change: friendlyName to cardType

### DIFF
--- a/credit-cards-example.js
+++ b/credit-cards-example.js
@@ -1,6 +1,6 @@
 const cards = [
   {
-    friendlyName: 'Visa',
+    cardType: 'Visa',
     cardNumber: '4242424242424242',
     nameOnCard: 'John Smith',
     expirationMonth: '01',
@@ -8,7 +8,7 @@ const cards = [
     securityCode: '123'
   },
   {
-    friendlyName: 'Mastercard',
+    cardType: 'Mastercard',
     cardNumber: '5555555555554444',
     nameOnCard: 'John Smith',
     expirationMonth: '01',


### PR DESCRIPTION
The friendlyName key may be misleading and can be referred to as a card type instead. With the example cards in place, cardType could be a better name as Visa and Mastercard are common card types.